### PR TITLE
FIxed heartbeats "Missing date" error. Added implementation of "durations" method.

### DIFF
--- a/src/WakaTime.php
+++ b/src/WakaTime.php
@@ -117,4 +117,25 @@ class WakaTime
         return $this->makeRequest("users/current/heartbeats?date={$date}" . $show);
     }
 
+    /**
+     * See https://wakatime.com/developers#durations for details.
+     *
+     * @param  [type] $date
+     * @param  string $project
+     * @param  string $branches
+     * @return [type]
+     */
+    public function durations($date, $project = null, $branches = NULL)
+    {
+        if ($project !== null) {
+            $project = "&project={$project}";
+        }
+
+        if ($branches !== null) {
+            $branches = "&branches={$branches}";
+        }
+
+        return $this->makeRequest("users/current/durations?date={$date}" . $project . $branches);
+    }
+
 }

--- a/src/WakaTime.php
+++ b/src/WakaTime.php
@@ -111,7 +111,7 @@ class WakaTime
     public function heartbeats($date, $show = null)
     {
         if ($show !== null) {
-            $show = "?show={$show}";
+            $show = "&show={$show}";
         }
 
         return $this->makeRequest("users/current/heartbeats?date={$date}" . $show);

--- a/tests/WakaTimeTest.php
+++ b/tests/WakaTimeTest.php
@@ -229,4 +229,20 @@ class WakaTimeTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $response);
     }
+
+    /**
+     * Durations
+     */
+
+    /** @test */
+    public function it_returns_durations_for_given_day()
+    {
+        $date     = '01/22/2016';
+        $project  = $this->project;
+        $branches = null;
+
+        $response = $this->wakatime->durations($date, $project, $branches);
+
+        $this->assertInternalType('array', $response);
+    }
 }

--- a/tests/WakaTimeTest.php
+++ b/tests/WakaTimeTest.php
@@ -223,8 +223,9 @@ class WakaTimeTest extends PHPUnit_Framework_TestCase
     public function it_returns_heartbeats_for_given_day()
     {
         $date = '01/22/2016';
+        $show = 'time,entity,type,project,language,branch,is_write,is_debugging';
 
-        $response = $this->wakatime->heartbeats($date);
+        $response = $this->wakatime->heartbeats($date, $show);
 
         $this->assertInternalType('array', $response);
     }


### PR DESCRIPTION
If pass `$show` parameter to heartbeats method, api returns `Missing date` error with code 400.

This PR fixes this issue. Tests included.
